### PR TITLE
Run ci process when merging/pushing to develop or main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ main, develop ]
 
 jobs:
   validations:


### PR DESCRIPTION
**Description**
Fix CI process to run when merging/pushing to `develop` and `main`

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington-gui.readthedocs.io/en/latest/community/contribution_guide.html)