### PR TITLE
Refactor font enum

### DIFF
--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -8,6 +8,7 @@ from lastversion.lastversion import latest
 from packaging.version import parse as parse_version
 
 from eddington_gui import __version__, has_matplotlib
+from eddington_gui.boxes.eddington_box import EddingtonBox
 from eddington_gui.boxes.figure_box import FigureBox
 from eddington_gui.boxes.main_box import MainBox
 from eddington_gui.boxes.plot_configuration_box import PlotConfigurationBox
@@ -120,17 +121,20 @@ class EddingtonGUI(toga.App):
 
     def on_start(self):
         """Move to main box."""
-        self.main_window.content = self.main_box
+        self.set_main_window_content(self.main_box)
 
     def on_back(self):
         """Move to welcome box."""
-        self.main_window.content = self.welcome_box
+        self.set_main_window_content(self.welcome_box)
+
+    def set_main_window_content(self, box: EddingtonBox):
+        self.main_window.content = box
+        self.update_content_font()
 
     def set_font_size(self, font_size: FontSize):
         """Set font size to all components in app."""
         self.__font_size = font_size
-        self.main_window.content.set_font_size(font_size)
-        self.main_window.content.refresh()
+        self.update_content_font()
 
     def check_latest_version(self):
         """Checker whether a new version of Eddington-GUI is available or not."""
@@ -159,6 +163,10 @@ class EddingtonGUI(toga.App):
         figure_window.app = self.app
         figure_window.content.set_font_size(self.__font_size)
         figure_window.show()
+
+    def update_content_font(self):
+        self.main_window.content.set_font_size(self.__font_size)
+        self.main_window.content.refresh()
 
 
 def main():

--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -128,6 +128,7 @@ class EddingtonGUI(toga.App):
         self.set_main_window_content(self.welcome_box)
 
     def set_main_window_content(self, box: EddingtonBox):
+        """Set the content of the window as the given box."""
         self.main_window.content = box
         self.update_content_font()
 
@@ -165,6 +166,7 @@ class EddingtonGUI(toga.App):
         figure_window.show()
 
     def update_content_font(self):
+        """Update the font of the content widget."""
         self.main_window.content.set_font_size(self.__font_size)
         self.main_window.content.refresh()
 

--- a/src/eddington_gui/boxes/eddington_box.py
+++ b/src/eddington_gui/boxes/eddington_box.py
@@ -21,8 +21,8 @@ class EddingtonBox(toga.Box):
             return
         if font_size is None:
             return
-        font_size_value = FontSize.get_font_size(font_size)
-        button_height_value = FontSize.get_button_height(font_size)
+        font_size_value = font_size.get_font_size()
+        button_height_value = font_size.get_button_height()
         for child in self.children:
             if isinstance(child, EddingtonBox):
                 child.set_font_size(font_size)

--- a/src/eddington_gui/boxes/eddington_box.py
+++ b/src/eddington_gui/boxes/eddington_box.py
@@ -9,10 +9,11 @@ class EddingtonBox(toga.Box):
 
     __font_size: FontSize
 
-    def __init__(self, *args, font_size=None, **kwargs):
+    def __init__(self, *args, font_size=None, fix_font_size: bool = False, **kwargs):
         """Initialize box."""
         super().__init__(*args, **kwargs)
         self.font_size = font_size
+        self.fix_font_size = fix_font_size
 
     def set_font_size(self, font_size: FontSize):
         """Set font size and refresh."""
@@ -24,7 +25,7 @@ class EddingtonBox(toga.Box):
         font_size_value = font_size.get_font_size()
         button_height_value = font_size.get_button_height()
         for child in self.children:
-            if isinstance(child, EddingtonBox):
+            if isinstance(child, EddingtonBox) and not child.fix_font_size:
                 child.set_font_size(font_size)
             if isinstance(child, toga.Button):
                 child.style.height = button_height_value

--- a/src/eddington_gui/boxes/parameters_box.py
+++ b/src/eddington_gui/boxes/parameters_box.py
@@ -80,7 +80,7 @@ class ParametersBox(LineBox):
 
     def build_parameter_box(self, index):
         """Build a new parameters box."""
-        font_size_value = FontSize.get_font_size(self.font_size)
+        font_size_value = self.font_size.get_font_size()
         return EddingtonBox(
             children=[
                 toga.Label(f"a[{index}]:", style=Pack(font_size=font_size_value)),

--- a/src/eddington_gui/boxes/welcome_box.py
+++ b/src/eddington_gui/boxes/welcome_box.py
@@ -25,19 +25,19 @@ class WelcomeBox(EddingtonBox):
     @classmethod
     def build_left_side(cls, on_start: Callable[[], None]):
         """Build the left side of the welcome box."""
-        return toga.Box(
+        return EddingtonBox(
             style=Pack(flex=1, direction=COLUMN),
             children=[
-                toga.Box(style=Pack(flex=1)),
-                toga.Box(
+                EddingtonBox(style=Pack(flex=1)),
+                EddingtonBox(
                     style=Pack(direction=ROW, alignment=CENTER),
                     children=[
-                        toga.Box(style=Pack(flex=1)),
+                        EddingtonBox(style=Pack(flex=1)),
                         toga.Button("Start", on_press=lambda _: on_start()),
-                        toga.Box(style=Pack(flex=1)),
+                        EddingtonBox(style=Pack(flex=1)),
                     ],
                 ),
-                toga.Box(style=Pack(flex=1)),
+                EddingtonBox(style=Pack(flex=1)),
             ],
         )
 
@@ -46,24 +46,24 @@ class WelcomeBox(EddingtonBox):
         """Build the right side of the welcome box."""
         logo_path = Path(__file__).parent.parent / "resources" / "eddington_gui.png"
         logo = toga.Image(str(logo_path))
-        return toga.Box(
+        return EddingtonBox(
             style=Pack(direction=COLUMN, alignment=CENTER, flex=1),
             children=[
-                toga.Box(style=Pack(flex=1)),
+                EddingtonBox(style=Pack(flex=1)),
                 toga.ImageView(
                     image=logo,
                     style=Pack(height=LOGO_SIZE, width=LOGO_SIZE, alignment=CENTER),
                 ),
-                toga.Box(
+                EddingtonBox(
                     style=Pack(direction=ROW, alignment=CENTER),
                     children=[
                         toga.Label(
-                            "Welcome to Eddington!",
-                            style=Pack(font_size=FontSize.LARGE.get_font_size()),
+                            "Welcome to Eddington!"
                         ),
                     ],
                 ),
-                toga.Box(style=Pack(flex=1)),
+                EddingtonBox(style=Pack(flex=1)),
                 FooterBox(),
             ],
+            fix_font_size=True
         )

--- a/src/eddington_gui/boxes/welcome_box.py
+++ b/src/eddington_gui/boxes/welcome_box.py
@@ -9,7 +9,7 @@ from travertino.constants import COLUMN, ROW
 
 from eddington_gui.boxes.eddington_box import EddingtonBox
 from eddington_gui.boxes.footer_box import FooterBox
-from eddington_gui.consts import LOGO_SIZE, FontSize
+from eddington_gui.consts import LOGO_SIZE
 
 
 class WelcomeBox(EddingtonBox):
@@ -57,13 +57,11 @@ class WelcomeBox(EddingtonBox):
                 EddingtonBox(
                     style=Pack(direction=ROW, alignment=CENTER),
                     children=[
-                        toga.Label(
-                            "Welcome to Eddington!"
-                        ),
+                        toga.Label("Welcome to Eddington!"),
                     ],
                 ),
                 EddingtonBox(style=Pack(flex=1)),
                 FooterBox(),
             ],
-            fix_font_size=True
+            fix_font_size=True,
         )

--- a/src/eddington_gui/boxes/welcome_box.py
+++ b/src/eddington_gui/boxes/welcome_box.py
@@ -59,9 +59,7 @@ class WelcomeBox(EddingtonBox):
                     children=[
                         toga.Label(
                             "Welcome to Eddington!",
-                            style=Pack(
-                                font_size=FontSize.get_font_size(FontSize.LARGE)
-                            ),
+                            style=Pack(font_size=FontSize.LARGE.get_font_size()),
                         ),
                     ],
                 ),

--- a/src/eddington_gui/consts.py
+++ b/src/eddington_gui/consts.py
@@ -42,24 +42,22 @@ class FontSize(IntEnum):
     LARGE = 3
     DEFAULT = 1
 
-    @classmethod
-    def get_font_size(cls, font_size: "FontSize"):
+    def get_font_size(self):
         """Get the actual font size from enum value."""
-        if font_size == FontSize.SMALL:
+        if self == FontSize.SMALL:
             return 10
-        if font_size == FontSize.MEDIUM:
+        if self == FontSize.MEDIUM:
             return 12
-        if font_size == FontSize.LARGE:
+        if self == FontSize.LARGE:
             return 15
         return SYSTEM_DEFAULT_FONT_SIZE
 
-    @classmethod
-    def get_button_height(cls, font_size: "FontSize"):
+    def get_button_height(self):
         """Get the height of button, related to font size."""
-        if font_size == FontSize.SMALL:
+        if self == FontSize.SMALL:
             return 25
-        if font_size == FontSize.MEDIUM:
+        if self == FontSize.MEDIUM:
             return 30
-        if font_size == FontSize.LARGE:
+        if self == FontSize.LARGE:
             return 35
         return None

--- a/src/eddington_gui/window/records_choice_window.py
+++ b/src/eddington_gui/window/records_choice_window.py
@@ -44,7 +44,7 @@ class RecordsChoiceWindow(toga.Window):  # pylint: disable=too-many-instance-att
         main_box = toga.Box(style=Pack(direction=COLUMN))
         data_box = toga.Box()
         statistics_box = toga.Box()
-        font_size_value = FontSize.get_font_size(font_size)
+        font_size_value = font_size.get_font_size()
         self.__update_on_check = True
         self.__statistics_labels = {
             (column, parameter): toga.Label(


### PR DESCRIPTION
**Description**
Small refactor in `FontSize` enum.
Also, made all boxes in `WelcomeBox` to inherit from `EddingtonBox`.
Lastly, made the right side of the box with fixed font size that doesn't change.

**Alternatives**
Not relevant.

**Additional context**
Python 3.10, Windows

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington-gui.readthedocs.io/en/latest/community/contribution_guide.html)