### PR TITLE
Save font size on exit

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -244,6 +244,7 @@ good-names=a,
            y,
            ax,
            ex,
+           fd,
            Run,
            _
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,10 @@ sources = ['src/eddington_gui']
 requires = [
     'toga-chart>=0.1.0',
     'openpyxl>=3.0.5',
-    'eddington==0.0.24.dev1',
+    'eddington==0.0.24.dev2',
     'lastversion>=1.2.4',
     'packaging>=20.8',
+    'platformdirs>=2.5.2'
 ]
 
 

--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -25,7 +25,7 @@ from eddington_gui.consts import (
     MAIN_WINDOW_SIZE,
     FontSize,
 )
-from eddington_gui.logging import create_logger, LoggerStream
+from eddington_gui.logging import LoggerStream, create_logger
 
 
 class EddingtonGUI(toga.App):

--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -2,7 +2,6 @@
 import logging
 import sys
 import webbrowser
-from traceback import format_exception
 from typing import Callable, Dict, Optional
 
 import requests
@@ -28,7 +27,7 @@ from eddington_gui.consts import (
 from eddington_gui.logging import LoggerStream, create_logger
 
 
-class EddingtonGUI(toga.App):
+class EddingtonGUI(toga.App):  # pylint: disable=too-many-instance-attributes
     """Main app instance."""
 
     logger: logging.Logger
@@ -56,7 +55,6 @@ class EddingtonGUI(toga.App):
         )
         sys.stdout = LoggerStream(self.logger, logging.INFO)
         sys.stderr = LoggerStream(self.logger, logging.ERROR)
-        sys.excepthook = self.exception_handler
 
         self.main_window = toga.MainWindow(
             title=self.formal_name, size=MAIN_WINDOW_SIZE
@@ -145,11 +143,13 @@ class EddingtonGUI(toga.App):
         """Move to welcome box."""
         self.set_main_window_content(self.welcome_box)
 
-    def save_style(self, app, **kwargs):
+    def save_style(self, app, **kwargs):  # pylint: disable=unused-argument
+        """Save style in application data."""
         self.app_data.save_style(font_size=self.__font_size.name)
         return True
 
     def load_style(self):
+        """Load style from app data."""
         style_dict = self.app_data.load_style()
         font_size = style_dict.get("font_size", FontSize.DEFAULT.name)
         self.set_font_size(FontSize[font_size])
@@ -196,14 +196,6 @@ class EddingtonGUI(toga.App):
         """Update the font of the content widget."""
         self.main_window.content.set_font_size(self.__font_size)
         self.main_window.content.refresh()
-
-    def exception_handler(self, exc_type, exc_value, exc_traceback):
-        self.logger.fatal("Uncaught exception was raised")
-        self.logger.fatal("".join(format_exception(exc_type, exc_value, exc_traceback)))
-        self.main_window.error_dialog(
-            "Fatal error", "Unhandled error has occurred. Aborting!"
-        )
-        sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
 
 def main():

--- a/src/eddington_gui/app_data.py
+++ b/src/eddington_gui/app_data.py
@@ -1,11 +1,11 @@
 import json
-from pathlib import Path
-from typing import Optional, Callable
 import shutil
+from pathlib import Path
+from typing import Callable, Optional
 
-from platformdirs import user_data_dir
+from platformdirs import user_data_dir, user_log_dir
 
-from eddington_gui.consts import FontSize, ENCODING
+from eddington_gui.consts import ENCODING
 
 
 class AppData:
@@ -22,6 +22,16 @@ class AppData:
     def style_data_path(self):
         return self.data_dir / "style.json"
 
+    @property
+    def log_dir(self):
+        log_dir = Path(user_log_dir(appname=self.name))
+        log_dir.mkdir(exist_ok=True, parents=True)
+        return log_dir
+
+    @property
+    def log_path(self) -> Path:
+        return self.log_dir / "eddington.log"
+
     def clear(self, confirmation_function: Optional[Callable[[], None]] = None):
         if confirmation_function is not None and not confirmation_function():
             return
@@ -29,11 +39,7 @@ class AppData:
 
     def save_style(self, **kwargs):
         with open(self.style_data_path, mode="w", encoding=ENCODING) as fd:
-            json.dump(
-                kwargs,
-                fd,
-                indent=2
-            )
+            json.dump(kwargs, fd, indent=2)
 
     def load_style(self):
         if not self.style_data_path.exists():

--- a/src/eddington_gui/app_data.py
+++ b/src/eddington_gui/app_data.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+from typing import Optional, Callable
+import shutil
+
+from platformdirs import user_data_dir
+
+from eddington_gui.consts import FontSize, ENCODING
+
+
+class AppData:
+    def __init__(self, name: str):
+        self.name = name
+
+    @property
+    def data_dir(self) -> Path:
+        data_dir = Path(user_data_dir(appname=self.name))
+        data_dir.mkdir(exist_ok=True, parents=True)
+        return data_dir
+
+    @property
+    def style_data_path(self):
+        return self.data_dir / "style.json"
+
+    def clear(self, confirmation_function: Optional[Callable[[], None]] = None):
+        if confirmation_function is not None and not confirmation_function():
+            return
+        shutil.rmtree(self.data_dir)
+
+    def save_style(self, **kwargs):
+        with open(self.style_data_path, mode="w", encoding=ENCODING) as fd:
+            json.dump(
+                kwargs,
+                fd,
+                indent=2
+            )
+
+    def load_style(self):
+        if not self.style_data_path.exists():
+            return {}
+        with open(self.style_data_path, mode="r", encoding=ENCODING) as fd:
+            return json.load(fd)

--- a/src/eddington_gui/app_data.py
+++ b/src/eddington_gui/app_data.py
@@ -1,3 +1,4 @@
+"""Application data to be saved from different runs."""
 import json
 import shutil
 from pathlib import Path
@@ -9,39 +10,49 @@ from eddington_gui.consts import ENCODING
 
 
 class AppData:
+    """Class for keeping application data and logs."""
+
     def __init__(self, name: str):
+        """Constructor."""
         self.name = name
 
     @property
     def data_dir(self) -> Path:
+        """App data directory."""
         data_dir = Path(user_data_dir(appname=self.name))
         data_dir.mkdir(exist_ok=True, parents=True)
         return data_dir
 
     @property
-    def style_data_path(self):
+    def style_data_path(self) -> Path:
+        """Path where style is saved."""
         return self.data_dir / "style.json"
 
     @property
-    def log_dir(self):
+    def log_dir(self) -> Path:
+        """Directory where all logs are saved."""
         log_dir = Path(user_log_dir(appname=self.name))
         log_dir.mkdir(exist_ok=True, parents=True)
         return log_dir
 
     @property
     def log_path(self) -> Path:
+        """Rotating path for logs."""
         return self.log_dir / "eddington.log"
 
     def clear(self, confirmation_function: Optional[Callable[[], None]] = None):
+        """Clear app data and all of its content."""
         if confirmation_function is not None and not confirmation_function():
             return
         shutil.rmtree(self.data_dir)
 
     def save_style(self, **kwargs):
+        """Save style to app data."""
         with open(self.style_data_path, mode="w", encoding=ENCODING) as fd:
             json.dump(kwargs, fd, indent=2)
 
     def load_style(self):
+        """Load style from app data."""
         if not self.style_data_path.exists():
             return {}
         with open(self.style_data_path, mode="r", encoding=ENCODING) as fd:

--- a/src/eddington_gui/consts.py
+++ b/src/eddington_gui/consts.py
@@ -6,6 +6,9 @@ from toga.style.pack import MONOSPACE
 
 ENCODING = "utf-8"
 
+DEFAULT_BACKUP_COUNT = 5  # Maximum of 5 backup files
+DEFAULT_MAX_BYTES = 1e7  # 10MB
+
 GITHUB_USER_NAME = "EddLabs"
 
 NO_VALUE = "----------"

--- a/src/eddington_gui/consts.py
+++ b/src/eddington_gui/consts.py
@@ -7,7 +7,7 @@ from toga.style.pack import MONOSPACE
 ENCODING = "utf-8"
 
 DEFAULT_BACKUP_COUNT = 5  # Maximum of 5 backup files
-DEFAULT_MAX_BYTES = 1e7  # 10MB
+DEFAULT_MAX_BYTES = 10_000_000  # 10MB
 
 GITHUB_USER_NAME = "EddLabs"
 

--- a/src/eddington_gui/consts.py
+++ b/src/eddington_gui/consts.py
@@ -4,6 +4,8 @@ from enum import IntEnum
 from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE
 from toga.style.pack import MONOSPACE
 
+ENCODING = "utf-8"
+
 GITHUB_USER_NAME = "EddLabs"
 
 NO_VALUE = "----------"

--- a/src/eddington_gui/logging.py
+++ b/src/eddington_gui/logging.py
@@ -1,3 +1,4 @@
+"""Logging classes and methods."""
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -9,6 +10,18 @@ from eddington_gui.consts import DEFAULT_BACKUP_COUNT, DEFAULT_MAX_BYTES, ENCODI
 def create_logger(
     name: str, level: int = logging.INFO, log_file: Optional[Path] = None
 ) -> logging.Logger:
+    """
+    Create a logger.
+
+    :param name: Name of the logger
+    :type name: str
+    :param level: Log level of the logger
+    :type level: int
+    :param log_file: Optional. File to save the logs to in addition to print to console/
+    :type log_file: Optional[Path]
+    :return: Logger with the given name and level
+    :rtype: logging.Logger
+    """
     logger = logging.getLogger(name)
     logger.level = level
     logger.addHandler(build_stream_handler())
@@ -18,13 +31,15 @@ def create_logger(
     return logger
 
 
-def build_stream_handler():
+def build_stream_handler() -> logging.StreamHandler:
+    """Build stream handler."""
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(build_formatter())
     return stream_handler
 
 
 def build_rotating_file_handler(log_file: Path):
+    """Build rotating file handler."""
     file_handler = RotatingFileHandler(
         log_file,
         encoding=ENCODING,
@@ -36,17 +51,22 @@ def build_rotating_file_handler(log_file: Path):
 
 
 def build_formatter():
+    """Build formatter for the log messages."""
     return logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 
 class LoggerStream:
+    """Stream class to override `sys.stdout` and `sys.stderr`."""
+
     def __init__(self, logger: logging.Logger, level: int):
+        """Constructor."""
         self.logger = logger
         self.level = level
 
-    def write(self, message):
+    def write(self, message: str):
+        """Write message to log."""
         if message != "\n":
             self.logger.log(level=self.level, msg=message)
 
     def flush(self):
-        pass
+        """Do nothing."""

--- a/src/eddington_gui/logging.py
+++ b/src/eddington_gui/logging.py
@@ -1,0 +1,53 @@
+import io
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+from eddington_gui.consts import DEFAULT_BACKUP_COUNT, DEFAULT_MAX_BYTES, ENCODING
+
+
+def create_logger(
+    name: str, level: int = logging.INFO, log_file: Optional[Path] = None
+) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.level = level
+    logger.addHandler(build_stream_handler())
+    if log_file is not None:
+        logger.addHandler(build_rotating_file_handler(log_file))
+        logger.info("Logs are saved in %s", log_file)
+    return logger
+
+
+def build_stream_handler():
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(build_formatter())
+    return stream_handler
+
+
+def build_rotating_file_handler(log_file: Path):
+    file_handler = RotatingFileHandler(
+        log_file,
+        encoding=ENCODING,
+        maxBytes=DEFAULT_MAX_BYTES,
+        backupCount=DEFAULT_BACKUP_COUNT,
+    )
+    file_handler.setFormatter(build_formatter())
+    return file_handler
+
+
+def build_formatter():
+    return logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+
+class LoggerStream:
+    def __init__(self, logger: logging.Logger, level: int):
+        self.logger = logger
+        self.level = level
+
+    def write(self, message):
+        if message != "\n":
+            self.logger.log(level=self.level, msg=message)
+
+    def flush(self):
+        pass

--- a/src/eddington_gui/logging.py
+++ b/src/eddington_gui/logging.py
@@ -1,4 +1,3 @@
-import io
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path


### PR DESCRIPTION
**Description**
Eddington-GUI now saved font size on exit.
Also, added logs support.

**Alternatives**
Not relevant.

**Additional context**
Python 3.10, Windows

**Declaration**
Please declare the following:

- [X] I have read the CODE_OF_CONDUCT
- [X] I have read and followed the contribution guide in [here](https://eddington-gui.readthedocs.io/en/latest/community/contribution_guide.html)