### PR TITLE
Bugfix/linux display bugs

### DIFF
--- a/docs/community/acknowledgment.rst
+++ b/docs/community/acknowledgment.rst
@@ -16,6 +16,7 @@ Contributors
 * Assaf Zohar
 * Ohad Nir
 * Yuval Bardugo
+* Ron Pelled
 
 Special Thanks
 --------------

--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -6,6 +6,8 @@ from typing import Callable, Dict, Optional
 
 import requests
 import toga
+from toga.style import Pack
+from travertino.constants import COLUMN
 from lastversion.lastversion import latest
 from packaging.version import parse as parse_version
 
@@ -62,7 +64,8 @@ class EddingtonGUI(toga.App):  # pylint: disable=too-many-instance-attributes
         self.on_exit = self.save_style
         self.welcome_box = WelcomeBox(on_start=self.on_start)
         self.main_box = MainBox(on_back=self.on_back)
-        self.main_window.content = self.welcome_box
+        self.main_window.content = EddingtonBox(style=Pack(direction=COLUMN))
+        self.main_window.content.add(self.welcome_box)
 
         self.check_latest_version()
         self.commands.add(
@@ -156,7 +159,9 @@ class EddingtonGUI(toga.App):  # pylint: disable=too-many-instance-attributes
 
     def set_main_window_content(self, box: EddingtonBox):
         """Set the content of the window as the given box."""
-        self.main_window.content = box
+        for child_box in self.main_window.content.children:
+            self.main_window.content.remove(child_box)
+        self.main_window.content.add(box)
         self.update_content_font()
 
     def set_font_size(self, font_size: FontSize):

--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -8,8 +8,6 @@ import requests
 import toga
 from lastversion.lastversion import latest
 from packaging.version import parse as parse_version
-from toga.style import Pack
-from travertino.constants import COLUMN
 
 from eddington_gui import __version__, has_matplotlib
 from eddington_gui.app_data import AppData

--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -64,8 +64,7 @@ class EddingtonGUI(toga.App):  # pylint: disable=too-many-instance-attributes
         self.on_exit = self.save_style
         self.welcome_box = WelcomeBox(on_start=self.on_start)
         self.main_box = MainBox(on_back=self.on_back)
-        self.main_window.content = EddingtonBox(style=Pack(direction=COLUMN))
-        self.main_window.content.add(self.welcome_box)
+        self.main_window.content = self.welcome_box
 
         self.check_latest_version()
         self.commands.add(
@@ -159,9 +158,7 @@ class EddingtonGUI(toga.App):  # pylint: disable=too-many-instance-attributes
 
     def set_main_window_content(self, box: EddingtonBox):
         """Set the content of the window as the given box."""
-        for child_box in self.main_window.content.children:
-            self.main_window.content.remove(child_box)
-        self.main_window.content.add(box)
+        self.main_window.content = box
         self.update_content_font()
 
     def set_font_size(self, font_size: FontSize):

--- a/src/eddington_gui/app.py
+++ b/src/eddington_gui/app.py
@@ -6,10 +6,10 @@ from typing import Callable, Dict, Optional
 
 import requests
 import toga
-from toga.style import Pack
-from travertino.constants import COLUMN
 from lastversion.lastversion import latest
 from packaging.version import parse as parse_version
+from toga.style import Pack
+from travertino.constants import COLUMN
 
 from eddington_gui import __version__, has_matplotlib
 from eddington_gui.app_data import AppData

--- a/src/eddington_gui/boxes/data_columns_box.py
+++ b/src/eddington_gui/boxes/data_columns_box.py
@@ -180,7 +180,7 @@ class DataColumnsBox(LineBox):  # pylint: disable=too-many-instance-attributes
         selection = toga.Selection(
             enabled=self.selection_enabled,
             on_select=on_select,
-            style=Pack(alignment=LEFT),
+            style=Pack(alignment=LEFT, flex=1),
         )
         self.add(selection)
         return selection

--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -44,8 +44,8 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
             min_value=1, max_value=5, value=1
         )
 
-        # This function uses self.polynomial_degree_input, so we
-        # attach it only after the relevant assignment
+        # The lambda function depends on the full initialization of self.polynomial_deree_input,
+        # so we attach the on_change hook only after the self.polynomial_degree_input is initialized
         self.polynomial_degree_input.on_change = (
             lambda widget: self.set_polynomial_degree()
         )

--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -43,9 +43,10 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
         self.polynomial_degree_input = toga.NumberInput(
             min_value=1,
             max_value=5,
-            value=1,
-            on_change=lambda widget: self.set_polynomial_degree(),
+            value=1
         )
+        # This function uses self.polynomial_degree_input, so we attach it after the relevant assignment
+        self.polynomial_degree_input.on_change = lambda widget: self.set_polynomial_degree()
 
         self.update_fitting_function_options()
         self.on_fitting_function_load = on_fitting_function_load

--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -32,6 +32,7 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
         self.add(toga.Label(text="Fitting function:"))
         self.fitting_function_selection = toga.Selection(
             on_select=self.load_select_fitting_function_name,
+            style=Pack(flex=1)
         )
         self.fitting_function_syntax = toga.TextInput(
             readonly=True,
@@ -70,7 +71,8 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
     @property
     def fitting_function_state(self):
         """Set fit function state."""
-        return self.fitting_function_selection.value
+        return self.
+.value
 
     @property
     def on_fitting_function_load(self) -> Optional[Callable]:

--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -72,8 +72,7 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
     @property
     def fitting_function_state(self):
         """Set fit function state."""
-        return self.
-.value
+        return self.fitting_function_selection.value
 
     @property
     def on_fitting_function_load(self) -> Optional[Callable]:

--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -43,7 +43,9 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
         self.polynomial_degree_input = toga.NumberInput(
             min_value=1, max_value=5, value=1
         )
-        # This function uses self.polynomial_degree_input, so we attach it after the relevant assignment
+
+        # This function uses self.polynomial_degree_input, so we
+        # attach it only after the relevant assignment
         self.polynomial_degree_input.on_change = (
             lambda widget: self.set_polynomial_degree()
         )

--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -44,8 +44,9 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
             min_value=1, max_value=5, value=1
         )
 
-        # The lambda function depends on the full initialization of self.polynomial_deree_input,
-        # so we attach the on_change hook only after the self.polynomial_degree_input is initialized
+        # The lambda function depends on the full initialization of
+        # self.polynomial_deree_input, so we attach the on_change hook
+        # only after the self.polynomial_degree_input is initialized
         self.polynomial_degree_input.on_change = (
             lambda widget: self.set_polynomial_degree()
         )

--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -31,8 +31,7 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
 
         self.add(toga.Label(text="Fitting function:"))
         self.fitting_function_selection = toga.Selection(
-            on_select=self.load_select_fitting_function_name,
-            style=Pack(flex=1)
+            on_select=self.load_select_fitting_function_name, style=Pack(flex=1)
         )
         self.fitting_function_syntax = toga.TextInput(
             readonly=True,
@@ -42,12 +41,12 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
 
         self.polynomial_degree_title = toga.Label("Degree:")
         self.polynomial_degree_input = toga.NumberInput(
-            min_value=1,
-            max_value=5,
-            value=1
+            min_value=1, max_value=5, value=1
         )
         # This function uses self.polynomial_degree_input, so we attach it after the relevant assignment
-        self.polynomial_degree_input.on_change = lambda widget: self.set_polynomial_degree()
+        self.polynomial_degree_input.on_change = (
+            lambda widget: self.set_polynomial_degree()
+        )
 
         self.update_fitting_function_options()
         self.on_fitting_function_load = on_fitting_function_load


### PR DESCRIPTION
**Description**
A total of 3 different bugs were identified and solved for Linux:
1) A callback for the fitting function window is called immediately when created under Linux, triggering a callback function that references an uninitialized variable.

![image](https://user-images.githubusercontent.com/10673651/202011497-b9aa1ea2-ae43-4ad6-b78e-fd855cf987cd.png)

I chose to attach this callback to the runtime only when the required members of the objects are initialized.

2) (Solved in Toga - https://github.com/beeware/toga/pull/1753, updated toga will be merged here after the toga PR is merged) The main window doesn't re-render itself when we change it's content box directly. Meaning, after pressing "start" this is the display:
![image](https://user-images.githubusercontent.com/10673651/202010550-b6b99f9a-d0da-46fe-bc1d-605880ff837c.png)

The only way I was able to find to do that was to hide and unhide the screen, causing a bad UX. Instead, I placed the main_box and welcome_box inside a second box, which is rendered properly on changes.

3) The fitting function label was overridden
![image](https://user-images.githubusercontent.com/10673651/202011560-eb09d7de-83b2-4866-a52f-8a58ec126f9c.png)
Minor display fix solved this issue.

The code looks like this now:
![image](https://user-images.githubusercontent.com/10673651/202012204-87f78397-c3ad-4a7d-a0c3-383f3ab85d25.png)